### PR TITLE
Support for BOOT2 = pfs:/EXECUTE.ELF

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,116 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: AcrossComments
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing : Both
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:        false
+  AfterClass:            true
+  AfterControlStatement: false
+  AfterEnum:             false
+  AfterFunction:         true
+  AfterNamespace:        true
+  AfterObjCDeclaration:  false
+  AfterStruct:           true
+  AfterUnion:            true
+  AfterExternBlock:      false
+  BeforeCatch:           false
+  BeforeElse:            false
+  BeforeLambdaBody:      false
+  BeforeWhile:           false
+  IndentBraces:          false
+  SplitEmptyFunction:    true
+  SplitEmptyRecord:      true
+  SplitEmptyNamespace:   true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ (IWYU pragma:|NOLINT)'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineBeforeAccessModifier: LogicalBlock
+FixNamespaceComments: true
+ForEachMacros:   []
+IncludeBlocks: Preserve
+IndentExternBlock: NoIndent
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 3
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 80
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 80
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 80
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+# uncomment below when clang >13 will be out
+# IndentPPDirectives: AfterHash
+# PPIndentWidth: 1
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig: http://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# 4 space indentation
+[*.{c,h,js,css,html}]
+indent_style = space
+indent_size = 4
+
+# 2 space indentation
+[*.{json,xml,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+# Tab indentation
+[Makefile*]
+indent_style = tab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
         git fetch --prune --unshallow
 
 
-    - name: Compile 
+    - name: Compile
       run: |
         make --trace
-    
+
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+#
+# NOTE! Please use 'git ls-files -i --exclude-standard -с'
+# command after changing this file, to see if there are
+# any tracked files which get ignored after the change.
+#
+# Normal rules
+#
+.*
+*.a
+*.diff
+*.elf
+*.ELF
+*.erl
+*.exe
+*.irx
+*.map
+*.o
+*.patch
+*.rej
+*.s
+*.zip
+*.ZIP
+*.a
+
+#
+# files that we don't want to ignore
+#
+!.gitignore
+!.gitattributes
+!.github
+!.editorconfig
+!.clang-format
+!modules/debug/*.irx

--- a/README.md
+++ b/README.md
@@ -2,48 +2,48 @@
 
 [![CI](https://github.com/ps2homebrew/OPL-Launcher/workflows/CI/badge.svg)](https://github.com/ps2homebrew/OPL-Launcher/actions?query=workflow%3ACI)
 
-OPL-Launcher reads "hdd0:/__common/OPL/conf_hdd.cfg" to launch "$OPL/OPNPS2LD.ELF".
+OPL-Launcher reads "hdd0:/\_\_common/OPL/conf_hdd.cfg" to launch "$OPL/OPNPS2LD.ELF".
 
 You can inject OPL-Launcher into APA using i.e HDL Dump:
-```hdl_dump.exe modify_header hdd<Disk Number>: <PP. Partition with PS2 game>```
+`hdl_dump.exe modify_header hdd<Disk Number>: <PP. Partition with PS2 game>`
 
 To do so, You must also prepare few files for the injection process:
 
-1. Signed executable which You can make by this application:
-https://www.psx-place.com/resources/kelftool-fmcb-compatible-fork.1104/
-```kelftool encrypt mbr OPL-Launcher.elf boot.kelf```
+1.  Signed executable which You can make by this application:
+    <https://www.psx-place.com/resources/kelftool-fmcb-compatible-fork.1104/>
 
-2. "system.cnf" file which contains:
-```
-BOOT2 = PATINFO
-VER = 1.00
-VMODE = NTSC
-HDDUNITPOWER = NICHDD
-```
+    `kelftool encrypt mbr OPL-Launcher.elf boot.kelf`
 
-3. Standrd PS2 game icon. Just take one from game save and rename it to "list.ico".
+2.  "system.cnf" file that contains:
 
-4. "icon.sys" file, which is not binary like in Memory Card case but fully text one (replace title0/1 by target game):
-```
-PS2X
-title0=ICO
-title1=SCUS-97113 (NTSC-U)
-bgcola=0
-bgcol0=0,0,0
-bgcol1=0,0,0
-bgcol2=0,0,0
-bgcol3=0,0,0
-lightdir0=1.0,-1.0,1.0
-lightdir1=-1.0,1.0,-1.0
-lightdir2=0.0,0.0,0.0
-lightcolamb=64,64,64
-lightcol0=64,64,64
-lightcol1=16,16,16
-lightcol2=0,0,0
-uninstallmes0=
-uninstallmes1=
-uninstallmes2=
-```
+        BOOT2 = PATINFO
+        VER = 1.00
+        VMODE = NTSC
+        HDDUNITPOWER = NICHDD
+
+3.  Standrd PS2 game icon. Just take one from game save and rename it to `list.ico`.
+
+4.  `icon.sys` file, which is not binary like in Memory Card case but fully text one (replace title0/1 by target game):
+
+        PS2X
+        title0=ICO
+        title1=SCUS-97113 (NTSC-U)
+        bgcola=0
+        bgcol0=0,0,0
+        bgcol1=0,0,0
+        bgcol2=0,0,0
+        bgcol3=0,0,0
+        lightdir0=1.0,-1.0,1.0
+        lightdir1=-1.0,1.0,-1.0
+        lightdir2=0.0,0.0,0.0
+        lightcolamb=64,64,64
+        lightcol0=64,64,64
+        lightcol1=16,16,16
+        lightcol2=0,0,0
+        uninstallmes0=
+        uninstallmes1=
+        uninstallmes2=
 
 ## Credits
+
 modified from miniOPL/diskload, credit to sp193 & l_oliveira

--- a/include/main.h
+++ b/include/main.h
@@ -22,56 +22,57 @@
 #include <io_common.h>
 
 #ifdef __EESIO_DEBUG
-	#include <sio.h>
-	#define DPRINTF(args...)	sio_printf(args)
-	#define DINIT()				sio_init(38400, 0, 0, 0, 0)
-	#define LOG(args...)		sio_printf(args)
+#include <sio.h>
+#define DPRINTF(args...) sio_printf(args)
+#define DINIT()          sio_init(38400, 0, 0, 0, 0)
+#define LOG(args...)     sio_printf(args)
 #else
-	#define LOG(args...)
-	#define DPRINTF(args...)
-	#define DINIT()
+#define LOG(args...)
+#define DPRINTF(args...)
+#define DINIT()
 #endif
 
-#define PS2PART_IDMAX			32
-#define HDL_GAME_NAME_MAX		64
-#define APA_FLAG_SUB			0x0001
-#define HDL_FS_MAGIC			0x1337
-#define HDL_GAME_DATA_OFFSET	0x100000 /* Sector 0x800 in the user data area. */
+#define PS2PART_IDMAX        32
+#define HDL_GAME_NAME_MAX    64
+#define APA_FLAG_SUB         0x0001
+#define HDL_FS_MAGIC         0x1337
+#define HDL_GAME_DATA_OFFSET 0x100000 /* Sector 0x800 in the user data area. */
 
 typedef struct
 {
-	char	partition_name[PS2PART_IDMAX + 1];
-	char	name[HDL_GAME_NAME_MAX + 1];
-	char	startup[8 + 1 + 3 + 1];
-	u8		hdl_compat_flags;
-	u8		ops2l_compat_flags;
-	u8		dma_type;
-	u8		dma_mode;
-	u32		layer_break;
-	int		disctype;
-	u32		start_sector;
-	u32		total_size_in_kb;
+    char partition_name[PS2PART_IDMAX + 1];
+    char name[HDL_GAME_NAME_MAX + 1];
+    char startup[8 + 1 + 3 + 1];
+    u8 hdl_compat_flags;
+    u8 ops2l_compat_flags;
+    u8 dma_type;
+    u8 dma_mode;
+    u32 layer_break;
+    int disctype;
+    u32 start_sector;
+    u32 total_size_in_kb;
 } hdl_game_info_t;
 
-typedef struct		// size = 1024
+typedef struct // size = 1024
 {
-	u32		magic; // HDL uses 0xdeadfeed magic here
-	u16		reserved;
-	u16		version;
-	char	gamename[160];
-	u8		hdl_compat_flags;
-	u8		ops2l_compat_flags;
-	u8		dma_type;
-	u8		dma_mode;
-	char	startup[60];
-	u32		layer1_start;
-	u32		discType;
-	int		num_partitions;
-	struct {
-		u32		part_offset;	// in MB
-		u32		data_start;		// in sectors
-		u32		part_size;		// in KB
-	} part_specs[65];
+    u32 magic; // HDL uses 0xdeadfeed magic here
+    u16 reserved;
+    u16 version;
+    char gamename[160];
+    u8 hdl_compat_flags;
+    u8 ops2l_compat_flags;
+    u8 dma_type;
+    u8 dma_mode;
+    char startup[60];
+    u32 layer1_start;
+    u32 discType;
+    int num_partitions;
+    struct
+    {
+        u32 part_offset; // in MB
+        u32 data_start;  // in sectors
+        u32 part_size;   // in KB
+    } part_specs[65];
 } hdl_apa_header;
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -181,7 +181,16 @@ int main(int argc, char *argv[])
 
     DPRINTF("Retrieving game information...\n");
 
-    if ((result = hddGetHDLGameInfo(PartitionName, &GameInfo)) >= 0) {
+    result = hddGetHDLGameInfo(PartitionName, &GameInfo);
+    if (result < 0) {
+        // some users use PP.<Partition> for storing game icons and settings
+        // for example BB.Navigator users and PSX DESR 1st gen (which just doesnt support PATINFO)
+        // they store game inside child partition: PC.<Partition>
+        PartitionName[1] = 'C';
+        result = hddGetHDLGameInfo(PartitionName, &GameInfo);
+    }
+
+    if (result >= 0) {
         char name[128];
         char oplPartition[256];
         char oplFilePath[256];
@@ -200,7 +209,7 @@ int main(int argc, char *argv[])
                         val++;
 
                     sprintf(name, val);
-                    //OPL adds windows CR+LF (0x0D 0x0A) .. remove that shiz from the string.. second check is 'just in case'
+                    // OPL adds windows CR+LF (0x0D 0x0A) .. remove that shiz from the string.. second check is 'just in case'
                     if ((val = strchr(name, '\r')) != NULL)
                         *val = '\0';
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Modified source control files.
Added support for non PATINFO users. BB Navigator and PSX DESR are taking some source files (like icons, description, logo) from the partition where it is booted from. Unfortunately, that means that you cannot store the game image in HDL format in the same partition. PSX DESR 1st gen doesn't even support PATINFO, so you need to store OPL-Launcher in that partition as well. To avoid this, you can install the game into the child partition (PC.<Partition>). In HDD OSD/BB Navigator/PSX XMB these 2 partitions (PP. and PC.) are treated as one partition.