### PR TITLE
Launch from PFS (non-game) partition

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -13,7 +13,7 @@
 #include <sbv_patches.h>
 #include <malloc.h>
 #include <hdd-ioctl.h>
-
+#include <libhdd.h>
 #include <elf-loader.h>
 
 #define NEWLIB_PORT_AWARE
@@ -50,6 +50,7 @@ typedef struct
     int disctype;
     u32 start_sector;
     u32 total_size_in_kb;
+    u8  is_pfs;
 } hdl_game_info_t;
 
 typedef struct // size = 1024

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,12 @@ static int hddGetHDLGameInfo(const char *partition, hdl_game_info_t *ginfo)
             // calculate total size
             size = PartStat.size;
 
+            // determine if partition has file system
+            if(PartStat.mode == FS_TYPE_PFS)
+                ginfo->is_pfs=1;
+            else
+                ginfo->is_pfs=0;
+
             strncpy(ginfo->partition_name, partition, sizeof(ginfo->partition_name) - 1);
             ginfo->partition_name[sizeof(ginfo->partition_name) - 1] = '\0';
             strncpy(ginfo->name, hdl_header->gamename, sizeof(ginfo->name) - 1);
@@ -205,16 +211,20 @@ int main(int argc, char *argv[])
 
         result = fileXioMount("pfs0:", oplPartition, FIO_MT_RDWR);
         if (result == 0) {
-            char *boot_argv[4];
-            char start[128];
+            if(!GameInfo.is_pfs){
+                char *boot_argv[4];
+                char start[128];
 
-            boot_argv[0] = GameInfo.startup;
-            sprintf(start, "%u", GameInfo.start_sector);
-            boot_argv[1] = start;
-            boot_argv[2] = name;
-            boot_argv[3] = "mini";
+                boot_argv[0] = GameInfo.startup;
+                sprintf(start, "%u", GameInfo.start_sector);
+                boot_argv[1] = start;
+                boot_argv[2] = name;
+                boot_argv[3] = "mini";
 
-            LoadELFFromFile(oplFilePath, 4, boot_argv); //args will be shifted +1 and oplFilePath will be the new argv0
+                LoadELFFromFile(oplFilePath, 4, boot_argv); //args will be shifted +1 and oplFilePath will be the new argv0
+            }
+            else
+                 LoadELFFromFile(oplFilePath, 0, NULL);
         }
     }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

The idea behind this PR is to allow OPL-Launcher be loaded from a partition with no game in it, for instance an executable partition with PFS filesystem.

This will help users to launch a single OPL installation from either game partition (behaving as miniOPL) or OPL GUI by using an executable partition from HDDOSD, otherwise OPL will hang on white screen.

The origin of this PR took place after this question at psx-place https://www.psx-place.com/threads/how-to-boot-opl-gui-through-hddosd-with-opl-launcher.35547
